### PR TITLE
Add formatter support

### DIFF
--- a/src/hooks/react/index.ts
+++ b/src/hooks/react/index.ts
@@ -1,5 +1,5 @@
 import { usePage } from '@inertiajs/react'
-import IntlMessageFormat from 'intl-messageformat'
+import { IntlMessageFormat } from 'intl-messageformat'
 
 // Define a type for the formatter function
 type Formatter = (message: string, data: Record<string, any>, locale: string) => string

--- a/src/hooks/react/index.ts
+++ b/src/hooks/react/index.ts
@@ -1,10 +1,40 @@
 import { usePage } from '@inertiajs/react'
+import IntlMessageFormat from 'intl-messageformat'
 
-export function useI18n() {
+// Define a type for the formatter function
+type Formatter = (message: string, data: Record<string, any>, locale: string) => string
+
+// Default formatter using IntlMessageFormat
+const defaultFormatter: Formatter = (message, vars, locale) => {
+  try {
+    const msg = new IntlMessageFormat(message, locale)
+    return msg.format(vars) as string
+  } catch (error) {
+    console.error(`Error formatting message: ${message}`, error)
+    return message // Fallback to raw message on error
+  }
+}
+
+export function useI18n(formatter: Formatter = defaultFormatter) {
   const page = usePage<{ locale: string; translations: Record<string, string> }>()
 
-  function t(key: string, fallback?: string): string {
-    return page.props.translations[key] ?? fallback ?? key
+  // Main t function with enhanced capabilities and backwards compatibility
+  function t(
+    key: string,
+    dataOrFallback?: Record<string, any> | string,
+    fallback?: string
+  ): string {
+    // Handle the old signature: t(key, fallback)
+    if (typeof dataOrFallback === 'string') {
+      return page.props.translations[key] ?? dataOrFallback ?? key
+    }
+
+    // Handle the new signature: t(key, data, fallback)
+    const message = page.props.translations[key] ?? fallback ?? key
+    if (dataOrFallback && typeof dataOrFallback === 'object') {
+      return formatter(message, dataOrFallback, page.props.locale)
+    }
+    return message
   }
 
   return {

--- a/src/hooks/vue/index.ts
+++ b/src/hooks/vue/index.ts
@@ -1,6 +1,6 @@
 import { usePage } from '@inertiajs/vue3'
 import { computed } from 'vue'
-import IntlMessageFormat from 'intl-messageformat'
+import { IntlMessageFormat } from 'intl-messageformat'
 
 // Define a type for the formatter function
 type Formatter = (message: string, data: Record<string, any>, locale: string) => string

--- a/src/hooks/vue/index.ts
+++ b/src/hooks/vue/index.ts
@@ -1,13 +1,43 @@
 import { usePage } from '@inertiajs/vue3'
 import { computed } from 'vue'
+import IntlMessageFormat from 'intl-messageformat'
 
-export function useI18n() {
+// Define a type for the formatter function
+type Formatter = (message: string, data: Record<string, any>, locale: string) => string
+
+// Default formatter using IntlMessageFormat
+const defaultFormatter: Formatter = (message, vars, locale) => {
+  try {
+    const msg = new IntlMessageFormat(message, locale)
+    return msg.format(vars) as string
+  } catch (error) {
+    console.error(`Error formatting message: ${message}`, error)
+    return message // Fallback to raw message on error
+  }
+}
+
+export function useI18n(formatter: Formatter = defaultFormatter) {
   const page = usePage<{ locale: string; translations: Record<string, string> }>()
 
   const locale = computed(() => page.props.locale)
 
-  function t(key: string, fallback?: string): string {
-    return page.props.translations[key] ?? fallback ?? key
+  // Main t function with enhanced capabilities and backwards compatibility
+  function t(
+    key: string,
+    dataOrFallback?: Record<string, any> | string,
+    fallback?: string
+  ): string {
+    // Handle the old signature: t(key, fallback)
+    if (typeof dataOrFallback === 'string') {
+      return page.props.translations[key] ?? dataOrFallback ?? key
+    }
+
+    // Handle the new signature: t(key, data, fallback)
+    const message = page.props.translations[key] ?? fallback ?? key
+    if (dataOrFallback && typeof dataOrFallback === 'object') {
+      return formatter(message, dataOrFallback, locale.value)
+    }
+    return message
   }
 
   return {


### PR DESCRIPTION
Resolves #1 

# Fix IntlMessageFormat import and enhance i18n hooks

## Changes
- Enhanced the `t` function to support ICU message formatting
- Added backwards compatibility for existing translations

## Usage Examples

### React
```tsx
import { useI18n } from '@adaloop/adonis-inertia-i18n/hooks/react'

function MyComponent() {
  const { t, locale } = useI18n()

  // Basic usage (existing behavior)
  t('greeting') // => "Hello"
  t('missing.key', 'Fallback') // => "Fallback"

  // New: Variable interpolation
  t('welcome', { name: 'John' }) // => "Welcome, John"
  
  // New: Complex formatting with ICU message format
  t('items', { count: 2 }) // => "You have 2 items"
  // Translation: "You have {count, number} {count, plural, one {item} other {items}}"

  // New: Fallback with variables
  t('missing.welcome', { name: 'John' }, 'Welcome!') // => "Welcome, John!"

  // Access current locale
  console.log(locale) // => "en"
}
```

### Vue
```vue
<script setup>
import { useI18n } from '@adaloop/adonis-inertia-i18n/hooks/vue'

const { t, locale } = useI18n()
</script>

<template>
  <!-- Basic usage (existing behavior) -->
  <h1>{{ t('greeting') }}</h1>
  <p>{{ t('missing.key', 'Fallback') }}</p>

  <!-- New: Variable interpolation -->
  <p>{{ t('welcome', { name: 'John' }) }}</p>

  <!-- New: Complex formatting with ICU message format -->
  <p>{{ t('items', { count: 2 }) }}</p>
  <!-- Translation: "You have {count, number} {count, plural, one {item} other {items}}" -->

  <!-- New: Fallback with variables -->
  <p>{{ t('missing.welcome', { name: 'John' }, 'Welcome!') }}</p>

  <!-- Access current locale -->
  <p>Current locale: {{ locale }}</p>
</template>
```

### Custom Formatter
You can also provide a custom formatter if needed:
```typescript
const customFormatter = (message: string, data: Record<string, any>, locale: string) => {
  // Your custom formatting logic
  return message.replace(/{(\w+)}/g, (_, key) => data[key] || '')
}

// React
const { t } = useI18n(customFormatter)

// Vue
const { t } = useI18n(customFormatter)
```

## Breaking Changes
None. All existing code using the old signature `t(key, fallback)` will continue to work as before.
